### PR TITLE
Crystal argument

### DIFF
--- a/dropletbuilder/dropletbuilder.py
+++ b/dropletbuilder/dropletbuilder.py
@@ -23,6 +23,9 @@ class Droplet(mbuild.Compound):
         compounds to fill the droplet with
     density: float or list of float
         target density for the droplet in kg/m^3
+    compound_ratio : float or list of float
+        Ratio of number of each compound to be put in sphere.  Only used in
+        the case of 'density' being specified and more than one 'fluid'
     lattice: mbuild.Lattice
         lattice to build droplet on
     lattice_compound: mbuild.Compound
@@ -40,6 +43,7 @@ class Droplet(mbuild.Compound):
     """
 
     def __init__(self, radius=2, angle=90.0, fluid=None, density=None,
+                compound_ratio=None,
                 lattice=None, lattice_compound=None, x=None, y=None):
 
         super(Droplet, self).__init__()
@@ -48,6 +52,18 @@ class Droplet(mbuild.Compound):
             raise ValueError('Fluid droplet compounds must be specified')
         if density is None:
             raise ValueError('Fluid density must be specified (units kg/m^3)')
+        if isinstance(fluid, list):
+            if compound_ratio is None:
+                msg = ("Determining 'n_compounds' for multiple fluids requires"
+                        " 'compound_ratio' to be specified.")
+                raise ValueError(msg)
+            if len(fluid) != len(compound_ratio):
+                msg = ("Length of 'compound_ratio' must equal length of"
+                        " 'compound'")
+                raise ValueError(msg)
+            if np.sum(compound_ratio) != 1:
+                msg = "`compound_ratio` must sum up to equal 1."
+                raise ValueError(msg)
 
         if x:
             if x < radius * 4:
@@ -129,7 +145,8 @@ class Droplet(mbuild.Compound):
         height = get_height(radius, angle)
         sphere_coords = [coords[0] / 2, coords[1] / 2, radius, radius]
         sphere = mbuild.fill_sphere(
-            compound=fluid, sphere=sphere_coords, density=density)
+            compound=fluid, sphere=sphere_coords, density=density,
+            compound_ratio=compound_ratio)
 
         to_remove = []
         for child in sphere.children:

--- a/dropletbuilder/tests/test_dropletbuilder.py
+++ b/dropletbuilder/tests/test_dropletbuilder.py
@@ -36,6 +36,13 @@ class BaseTest:
         water = mbuild.load(get_fn('tip3p.mol2'))
         return Droplet(radius=1, angle=90.0, fluid=water, density=997, x=4, y=4)
 
+    @pytest.fixture
+    def DropletMixture(self):
+        from dropletbuilder.dropletbuilder import Droplet
+        water = mbuild.load(get_fn('tip3p.mol2'))
+        ch3cn = mbuild.load(get_fn('ch3cn.mol2'))
+        return Droplet(radius=1, angle=90.0, fluid=[water, ch3cn],
+                density=[997, 786], compound_ratio=[0.5, 0.5], x=4, y=4)
 
 """
 Unit Tests for Droplet class.
@@ -180,3 +187,32 @@ class TestDropletBuilder(BaseTest):
                         DropletWithDims.surface_height + 0.001):
                     assert False
         assert True
+
+    def test_compound_ratio(self, DropletMixture):
+        droplet = DropletMixture
+
+    def test_droplet_with_missing_compound_ratio(self):
+        from dropletbuilder.dropletbuilder import Droplet
+        water = mbuild.load(get_fn('tip3p.mol2'))
+        ch3cn = mbuild.load(get_fn('ch3cn.mol2'))
+        with pytest.raises(ValueError, match="Determining 'n_compounds'"):
+            Droplet(radius=1, angle=90.0, fluid=[water, ch3cn],
+                    density=[997, 786], x=4, y=4)
+
+    def test_droplet_incorrect_compound_ratio_length(self):
+        from dropletbuilder.dropletbuilder import Droplet
+        water = mbuild.load(get_fn('tip3p.mol2'))
+        ch3cn = mbuild.load(get_fn('ch3cn.mol2'))
+        with pytest.raises(ValueError, match="Length of 'compound_ratio'"):
+            Droplet(radius=1, angle=90.0, fluid=[water, ch3cn],
+                    density=[997, 786], compound_ratio=[0.3, 0.4, 0.2],
+                    x=4, y=4)
+
+    def test_droplet_incorrect_compound_ratio_sum(self):
+        from dropletbuilder.dropletbuilder import Droplet
+        water = mbuild.load(get_fn('tip3p.mol2'))
+        ch3cn = mbuild.load(get_fn('ch3cn.mol2'))
+        with pytest.raises(ValueError, match="must sum up to equal 1"):
+            Droplet(radius=1, angle=90.0, fluid=[water, ch3cn],
+                    density=[997, 786], compound_ratio=[0.3, 0.4],
+                    x=4, y=4)


### PR DESCRIPTION
## Description
Right now, there is no argument in `mb.Lattice` to create crystal structure of varying surfaces (110, 111, etc.). The workaround I came up with is to use the function in ASE: https://wiki.fysik.dtu.dk/ase/ase/build/surface.html and save them out as a `gro` file.  This workflow requires `Droplet` to accept a full lattice as a Compound, rather than building the lattice from scratch.  Here I am adding an argument `full_lattice` which is `False` by default.  If True, then `Droplet` expects `lattice_compound` to be the final structure in which the droplet will be built on.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go